### PR TITLE
Add background service using flutter_background package

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <application
         android:label="flutter_time_lock"
         android:name="${applicationName}"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'dart:io';
 import 'dart:convert';
+import 'package:flutter_background/flutter_background.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await FlutterBackground.initialize();
   runApp(MyApp());
 }
 
@@ -36,6 +39,7 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
   void initState() {
     super.initState();
     _checkAndCreateConfigFile();
+    _startBackgroundService();
   }
 
   Future<void> _checkAndCreateConfigFile() async {
@@ -60,6 +64,33 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
         config = defaultConfig;
       });
     }
+  }
+
+  Future<void> _startBackgroundService() async {
+    await FlutterBackground.enableBackgroundExecution();
+    Timer.periodic(Duration(minutes: int.parse(config['lockInterval'])), (timer) {
+      _showLockDialog();
+    });
+  }
+
+  void _showLockDialog() {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('Lock Alert'),
+          content: Text('Time to lock the device!'),
+          actions: <Widget>[
+            TextButton(
+              child: Text('OK'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
+  flutter_background: ^0.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes #8

Implement a background service to run efficiently in the background of the app using the `flutter_background` package.

* **Add dependency**: Add `flutter_background` package to `pubspec.yaml`.
* **Initialize background service**: Update `lib/main.dart` to import and initialize `flutter_background` package in the `main` function. Configure the background service to display a popup dialog based on the configured lock timer.
* **Permissions**: Update `android/app/src/main/AndroidManifest.xml` to include necessary permissions for background services: `FOREGROUND_SERVICE`, `WAKE_LOCK`, and `RECEIVE_BOOT_COMPLETED`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bertusviljoen/flutter_time_lock/pull/9?shareId=c7c55258-7987-4696-a016-2ab7d6a66764).