### PR TITLE
Add configuration screen to update and save values

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,7 +32,29 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: ConfigurationScreen(),
+      home: MainScreen(),
+    );
+  }
+}
+
+class MainScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Main Screen'),
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => ConfigurationScreen()),
+            );
+          },
+          child: Text('Go to Configuration'),
+        ),
+      ),
     );
   }
 }
@@ -48,8 +70,11 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
     'childPin': '',
     'adultPin': '',
     'lockTime': '',
-    'lockInterval': ''
+    'lockInterval': '',
+    'timerUnit': 'seconds'
   };
+
+  final _formKey = GlobalKey<FormState>();
 
   @override
   void initState() {
@@ -76,19 +101,34 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
     final path = '${directory.path}/config.json';
     final file = File(path);
 
-    if (await file.exists()) {
-      final contents = await file.readAsString();
-      setState(() {
-        config = jsonDecode(contents);
-      });
-    } else {
+    try {
+      if (await file.exists()) {
+        final contents = await file.readAsString();
+        setState(() {
+          config = jsonDecode(contents);
+        });
+      } else {
+        final defaultConfig = {
+          'childPin': '1234',
+          'adultPin': '5678',
+          'lockTime': '1',
+          'lockInterval': '2',
+          'timerUnit': 'seconds'
+        };
+        await file.writeAsString(jsonEncode(defaultConfig));
+        setState(() {
+          config = defaultConfig;
+        });
+      }
+    } catch (e) {
+      print('Error reading configuration file: $e');
       final defaultConfig = {
         'childPin': '1234',
         'adultPin': '5678',
         'lockTime': '1',
-        'lockInterval': '2'
+        'lockInterval': '2',
+        'timerUnit': 'seconds'
       };
-      await file.writeAsString(jsonEncode(defaultConfig));
       setState(() {
         config = defaultConfig;
       });
@@ -148,21 +188,116 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
     _showSystemAlert(); // Always use system alert instead of Flutter dialog
   }
 
+  Future<void> _saveConfig() async {
+    if (_formKey.currentState!.validate()) {
+      _formKey.currentState!.save();
+      final directory = await Directory.systemTemp.createTemp();
+      final path = '${directory.path}/config.json';
+      final file = File(path);
+      await file.writeAsString(jsonEncode(config));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Configuration saved')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text('Flutter Time Lock'),
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text('Child Pin: ${config['childPin']}'),
-            Text('Adult Pin: ${config['adultPin']}'),
-            Text('Lock Time: ${config['lockTime']} mins'),
-            Text('Lock Interval: ${config['lockInterval']} mins'),
-          ],
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: <Widget>[
+              TextFormField(
+                initialValue: config['childPin'],
+                decoration: InputDecoration(labelText: 'Child Pin'),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a child pin';
+                  }
+                  return null;
+                },
+                onSaved: (value) {
+                  config['childPin'] = value!;
+                },
+              ),
+              TextFormField(
+                initialValue: config['adultPin'],
+                decoration: InputDecoration(labelText: 'Adult Pin'),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter an adult pin';
+                  }
+                  return null;
+                },
+                onSaved: (value) {
+                  config['adultPin'] = value!;
+                },
+              ),
+              TextFormField(
+                initialValue: config['lockTime'],
+                decoration: InputDecoration(labelText: 'Lock Time'),
+                keyboardType: TextInputType.number,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a lock time';
+                  }
+                  if (int.tryParse(value) == null) {
+                    return 'Please enter a valid number';
+                  }
+                  return null;
+                },
+                onSaved: (value) {
+                  config['lockTime'] = value!;
+                },
+              ),
+              TextFormField(
+                initialValue: config['lockInterval'],
+                decoration: InputDecoration(labelText: 'Lock Interval'),
+                keyboardType: TextInputType.number,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a lock interval';
+                  }
+                  if (int.tryParse(value) == null) {
+                    return 'Please enter a valid number';
+                  }
+                  return null;
+                },
+                onSaved: (value) {
+                  config['lockInterval'] = value!;
+                },
+              ),
+              DropdownButtonFormField<String>(
+                value: config['timerUnit'],
+                decoration: InputDecoration(labelText: 'Timer Unit'),
+                items: ['seconds', 'minutes']
+                    .map((unit) => DropdownMenuItem(
+                          value: unit,
+                          child: Text(unit),
+                        ))
+                    .toList(),
+                onChanged: (value) {
+                  setState(() {
+                    config['timerUnit'] = value!;
+                  });
+                },
+                onSaved: (value) {
+                  config['timerUnit'] = value!;
+                },
+              ),
+              SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _saveConfig,
+                child: Text('Save'),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Fixes #10

Add a configuration screen to the application to view and update configuration values.

* Update `MyApp` class to point to the main screen instead of `ConfigurationScreen`.
* Add `MainScreen` class with a button to navigate to `ConfigurationScreen`.
* Update `_ConfigurationScreenState` class to include input fields for configuration values using `TextFormField` widgets.
* Add validation logic to the input fields using `TextFormField` validators.
* Add a `DropdownButton` widget to select the timer unit (seconds or minutes).
* Add a `Save` button to save the configuration values and write them to the file.
* Handle errors when reading the configuration file using a `try-catch` block in `_checkAndCreateConfigFile`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bertusviljoen/flutter_time_lock/pull/11?shareId=5ccbbb71-2631-4677-9b93-fd08e7b98ed2).