### PR TITLE
Disable WiFi during showOverlayWindow

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <application
         android:label="flutter_time_lock"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/example/flutter_time_lock/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_time_lock/MainActivity.kt
@@ -3,6 +3,7 @@ package com.example.flutter_time_lock
 import android.content.Intent
 import android.graphics.PixelFormat
 import android.net.Uri
+import android.net.wifi.WifiManager
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
@@ -84,8 +85,8 @@ class MainActivity: FlutterFragmentActivity() {
 
         // Create layout parameters for the overlay
         val params = WindowManager.LayoutParams(
-            WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.WRAP_CONTENT,
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.MATCH_PARENT,
             WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
             WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
                     or WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
@@ -95,9 +96,6 @@ class MainActivity: FlutterFragmentActivity() {
             PixelFormat.TRANSLUCENT
         ).apply {
             gravity = Gravity.CENTER
-            // Make the window slightly larger to be more noticeable
-            width = WindowManager.LayoutParams.MATCH_PARENT
-            horizontalMargin = 16f // Add some margin on the sides
         }
 
         // Add the view to the window manager
@@ -107,6 +105,9 @@ class MainActivity: FlutterFragmentActivity() {
             e.printStackTrace()
             callback(false)
         }
+
+        // Disable WiFi
+        disableWiFi()
     }
 
     private fun removeOverlayWindow() {
@@ -118,6 +119,11 @@ class MainActivity: FlutterFragmentActivity() {
         } catch (e: Exception) {
             e.printStackTrace()
         }
+    }
+
+    private fun disableWiFi() {
+        val wifiManager = applicationContext.getSystemService(WIFI_SERVICE) as WifiManager
+        wifiManager.isWifiEnabled = false
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Fixes #18

Add functionality to disable WiFi during `showOverlayWindow` and make the overlay window cover 99% of the screen.

* **AndroidManifest.xml**
  - Add permissions to control WiFi using `android.permission.CHANGE_WIFI_STATE`.
  - Add permissions to access WiFi state using `android.permission.ACCESS_WIFI_STATE`.

* **MainActivity.kt**
  - Import `android.net.wifi.WifiManager`.
  - Add method `disableWiFi` to disable WiFi using `WifiManager`.
  - Call `disableWiFi` method inside `showOverlayWindow` method.
  - Update `WindowManager.LayoutParams` in `showOverlayWindow` to use `MATCH_PARENT` for width and height.
  - Remove `horizontalMargin` from `WindowManager.LayoutParams` in `showOverlayWindow`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bertusviljoen/flutter_time_lock/pull/19?shareId=133274b7-20db-4e43-b0b7-6f6d9e5de1a3).