### PR TITLE
Add permissions screen to display and request app permissions

### DIFF
--- a/android/app/src/main/kotlin/com/example/flutter_time_lock/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_time_lock/MainActivity.kt
@@ -50,6 +50,30 @@ class MainActivity: FlutterFragmentActivity() {
                     startActivity(intent)
                     result.success(null)
                 }
+                call.method == "checkForegroundServicePermission" -> {
+                    result.success(true) // Foreground service permission is always granted
+                }
+                call.method == "requestForegroundServicePermission" -> {
+                    result.success(true) // Foreground service permission is always granted
+                }
+                call.method == "checkWakeLockPermission" -> {
+                    result.success(true) // Wake lock permission is always granted
+                }
+                call.method == "requestWakeLockPermission" -> {
+                    result.success(true) // Wake lock permission is always granted
+                }
+                call.method == "checkReceiveBootCompletedPermission" -> {
+                    result.success(true) // Receive boot completed permission is always granted
+                }
+                call.method == "requestReceiveBootCompletedPermission" -> {
+                    result.success(true) // Receive boot completed permission is always granted
+                }
+                call.method == "checkAccessWifiStatePermission" -> {
+                    result.success(true) // Access WiFi state permission is always granted
+                }
+                call.method == "requestAccessWifiStatePermission" -> {
+                    result.success(true) // Access WiFi state permission is always granted
+                }
                 call.method == "showSystemAlert" -> {
                     if (!Settings.canDrawOverlays(this)) {
                         result.error("PERMISSION_DENIED", "Overlay permission not granted", null)

--- a/lib/screens/configuration_screen.dart
+++ b/lib/screens/configuration_screen.dart
@@ -17,31 +17,6 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
   @override
   void initState() {
     super.initState();
-    _checkOverlayPermission();
-    _checkWifiPermission();
-  }
-
-  Future<void> _checkOverlayPermission() async {
-    try {
-      bool hasPermission =
-          await platform.invokeMethod('checkOverlayPermission');
-      if (!hasPermission) {
-        await platform.invokeMethod('requestOverlayPermission');
-      }
-    } catch (e) {
-      print('Error checking overlay permission: $e');
-    }
-  }
-
-  Future<void> _checkWifiPermission() async {
-    try {
-      bool hasPermission = await platform.invokeMethod('checkWifiPermission');
-      if (!hasPermission) {
-        await platform.invokeMethod('requestWifiPermission');
-      }
-    } catch (e) {
-      print('Error checking wifi permission: $e');
-    }
   }
 
   Future<void> _saveConfig() async {

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'configuration_screen.dart';
+import 'permissions_screen.dart';
 
 class MainScreen extends StatelessWidget {
   @override
@@ -9,14 +10,29 @@ class MainScreen extends StatelessWidget {
         title: Text('Main Screen'),
       ),
       body: Center(
-        child: ElevatedButton(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) => ConfigurationScreen()),
-            );
-          },
-          child: Text('Go to Configuration'),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => ConfigurationScreen()),
+                );
+              },
+              child: Text('Go to Configuration'),
+            ),
+            SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => PermissionsScreen()),
+                );
+              },
+              child: Text('Go to Permissions'),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/permissions_screen.dart
+++ b/lib/screens/permissions_screen.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class PermissionsScreen extends StatefulWidget {
+  @override
+  _PermissionsScreenState createState() => _PermissionsScreenState();
+}
+
+class _PermissionsScreenState extends State<PermissionsScreen> {
+  static const platform = MethodChannel('com.example.flutter_time_lock/system');
+  bool _overlayPermission = false;
+  bool _wifiPermission = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkOverlayPermission();
+    _checkWifiPermission();
+  }
+
+  Future<void> _checkOverlayPermission() async {
+    try {
+      bool hasPermission =
+          await platform.invokeMethod('checkOverlayPermission');
+      setState(() {
+        _overlayPermission = hasPermission;
+      });
+    } catch (e) {
+      print('Error checking overlay permission: $e');
+    }
+  }
+
+  Future<void> _checkWifiPermission() async {
+    try {
+      bool hasPermission = await platform.invokeMethod('checkWifiPermission');
+      setState(() {
+        _wifiPermission = hasPermission;
+      });
+    } catch (e) {
+      print('Error checking wifi permission: $e');
+    }
+  }
+
+  Future<void> _requestOverlayPermission() async {
+    try {
+      await platform.invokeMethod('requestOverlayPermission');
+      _checkOverlayPermission();
+    } catch (e) {
+      print('Error requesting overlay permission: $e');
+    }
+  }
+
+  Future<void> _requestWifiPermission() async {
+    try {
+      await platform.invokeMethod('requestWifiPermission');
+      _checkWifiPermission();
+    } catch (e) {
+      print('Error requesting wifi permission: $e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Permissions Screen'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: <Widget>[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text('Overlay Permission'),
+                Switch(
+                  value: _overlayPermission,
+                  onChanged: (value) {
+                    if (!value) {
+                      _requestOverlayPermission();
+                    }
+                  },
+                ),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text('WiFi Permission'),
+                Switch(
+                  value: _wifiPermission,
+                  onChanged: (value) {
+                    if (!value) {
+                      _requestWifiPermission();
+                    }
+                  },
+                ),
+              ],
+            ),
+            ElevatedButton(
+              onPressed: _requestOverlayPermission,
+              child: Text('Request Overlay Permission'),
+            ),
+            ElevatedButton(
+              onPressed: _requestWifiPermission,
+              child: Text('Request WiFi Permission'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Fixes #20

Add a new permissions screen to display and request app permissions.

* **New Permissions Screen**: Add `lib/screens/permissions_screen.dart` to display the status of overlay and WiFi permissions using `Text` and `Switch` widgets, and provide `ElevatedButton` widgets to request permissions again.
* **Main Screen Update**: Modify `lib/screens/main_screen.dart` to include a button that navigates to the new permissions screen.
* **Configuration Screen Update**: Remove permission checks and requests from `lib/screens/configuration_screen.dart`.
* **MainActivity Update**: Add methods in `android/app/src/main/kotlin/com/example/flutter_time_lock/MainActivity.kt` to check and request permissions for `FOREGROUND_SERVICE`, `WAKE_LOCK`, `RECEIVE_BOOT_COMPLETED`, and `ACCESS_WIFI_STATE`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bertusviljoen/flutter_time_lock/pull/21?shareId=fa91c0d6-2e96-4715-8b93-245631f5bfd5).