### PR TITLE
Update app configuration

### DIFF
--- a/lib/configuration.dart
+++ b/lib/configuration.dart
@@ -6,11 +6,7 @@ import 'package:flutter/material.dart';
 class Configuration {
   static const String _configFileName = 'config.json';
   static Map<String, dynamic> _config = {
-    'childPin': '',
     'adultPin': '',
-    'lockTime': '',
-    'lockInterval': '',
-    'timerUnit': 'seconds',
     'unlockDuration': 20,
     'lockTimeout': 10
   };
@@ -33,11 +29,7 @@ class Configuration {
         _config = jsonDecode(contents);
       } else {
         final defaultConfig = {
-          'childPin': '1234',
           'adultPin': '5678',
-          'lockTime': '1',
-          'lockInterval': '2',
-          'timerUnit': 'seconds',
           'unlockDuration': 20,
           'lockTimeout': 10
         };
@@ -47,11 +39,7 @@ class Configuration {
     } catch (e) {
       print('Error reading configuration file: $e');
       final defaultConfig = {
-        'childPin': '1234',
         'adultPin': '5678',
-        'lockTime': '1',
-        'lockInterval': '2',
-        'timerUnit': 'seconds',
         'unlockDuration': 20,
         'lockTimeout': 10
       };

--- a/lib/screens/configuration_screen.dart
+++ b/lib/screens/configuration_screen.dart
@@ -43,19 +43,6 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
           child: Column(
             children: <Widget>[
               TextFormField(
-                initialValue: config['childPin'],
-                decoration: InputDecoration(labelText: 'Child Pin'),
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter a child pin';
-                  }
-                  return null;
-                },
-                onSaved: (value) {
-                  config['childPin'] = value!;
-                },
-              ),
-              TextFormField(
                 initialValue: config['adultPin'],
                 decoration: InputDecoration(labelText: 'Adult Pin'),
                 validator: (value) {
@@ -66,40 +53,6 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
                 },
                 onSaved: (value) {
                   config['adultPin'] = value!;
-                },
-              ),
-              TextFormField(
-                initialValue: config['lockTime'],
-                decoration: InputDecoration(labelText: 'Lock Time'),
-                keyboardType: TextInputType.number,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter a lock time';
-                  }
-                  if (int.tryParse(value) == null) {
-                    return 'Please enter a valid number';
-                  }
-                  return null;
-                },
-                onSaved: (value) {
-                  config['lockTime'] = value!;
-                },
-              ),
-              TextFormField(
-                initialValue: config['lockInterval'],
-                decoration: InputDecoration(labelText: 'Lock Interval'),
-                keyboardType: TextInputType.number,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter a lock interval';
-                  }
-                  if (int.tryParse(value) == null) {
-                    return 'Please enter a valid number';
-                  }
-                  return null;
-                },
-                onSaved: (value) {
-                  config['lockInterval'] = value!;
                 },
               ),
               TextFormField(
@@ -136,24 +89,6 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
                 },
                 onSaved: (value) {
                   config['lockTimeout'] = int.parse(value!);
-                },
-              ),
-              DropdownButtonFormField<String>(
-                value: config['timerUnit'],
-                decoration: InputDecoration(labelText: 'Timer Unit'),
-                items: ['seconds', 'minutes']
-                    .map((unit) => DropdownMenuItem(
-                          value: unit,
-                          child: Text(unit),
-                        ))
-                    .toList(),
-                onChanged: (value) {
-                  setState(() {
-                    config['timerUnit'] = value!;
-                  });
-                },
-                onSaved: (value) {
-                  config['timerUnit'] = value!;
                 },
               ),
               SizedBox(height: 20),


### PR DESCRIPTION
Fixes #24

Update the app configuration to remove unnecessary fields and update the form.

* **lib/configuration.dart**
  - Remove `childPin`, `lockTime`, `lockInterval`, and `timerUnit` fields from `_config` map and default configuration.
  - Update `loadConfig` method to remove references to `childPin`, `lockTime`, `lockInterval`, and `timerUnit`.
  - Update `defaultConfig` to only include `adultPin`, `unlockDuration`, and `lockTimeout`.

* **lib/screens/configuration_screen.dart**
  - Remove `childPin`, `lockTime`, `lockInterval`, and `timerUnit` fields from the form.
  - Update form to only include `adultPin`, `unlockDuration`, and `lockTimeout` fields.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bertusviljoen/flutter_time_lock/pull/25?shareId=4aeb94af-2672-413b-a79e-570e6e9365d0).